### PR TITLE
callbacks: return new fetch promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ $.ajax('http://api.trello.com/me', me => {
 
 ```js
 fetch('http://api.trello.com/me')
-    .then(({ id }) => `http://api.trello.com/tasks/${id}`)
+    .then(({ id }) => fetch(`http://api.trello.com/tasks/${id}`))
     .filter(prop('done'))
     .tap(console.log)
 ```


### PR DESCRIPTION
The standard fetch function does not have a `tap` either, it is bluebird specific method, but I just ignored that fact for simplicity.

For the browser it would be something like:

```js
const toJson = response => response.json()
const tap = data => {
  console.log(data)
  return data
}

fetch('https://api.ipify.org?format=json')
  .then(toJson)
  .then(({ ip }) => fetch(`https://geoip.nekudo.com/api/${ip}/en`))
  .then(toJson)
  .then(tap)
```

